### PR TITLE
Shadow offset

### DIFF
--- a/Canvas.js
+++ b/Canvas.js
@@ -760,15 +760,14 @@
  * @param {integer} y shadowOffsetY
  */
 					shadowOffset = function(x, y) {
-						if (x !== undefined &&
-							y !== undefined){
+						if (x !== undefined) {
+							context.shadowOffsetX = x;
 
-							context.shadowOffsetX = x;
-							context.shadowOffsetY = y;
-							return this;
-						} else if (x !== undefined) {
-							context.shadowOffsetX = x;
-							context.shadowOffsetY = x;
+							if (y !== undefined) {
+								context.shadowOffsetY = y;
+							} else {
+								context.shadowOffsetY = x;
+							}
 							return this;
 						} else {
 							return {

--- a/Canvas.js
+++ b/Canvas.js
@@ -754,7 +754,7 @@
  * Gets/Sets shadowOffsetX and shadowOffsetY in one call.
  * Passing no parameters returns an object containing the x and y offsets
  * shadowOffset().x === shadowOffsetX() && shadowOffset().y === shadowOffsetY()
- * 
+ *
  * @param {integer} x shadowOffsetX
  * @param {integer} y shadowOffsetY
  */
@@ -765,8 +765,11 @@
 							context.shadowOffsetX = x;
 							context.shadowOffsetY = y;
 							return this;
-						}
-						else {
+						} else if (x !== undefined) {
+							context.shadowOffsetX = x;
+							context.shadowOffsetY = x;
+							return this;
+						} else {
 							return {
 								x: context.shadowOffsetX,
 								y: context.shadowOffsetY

--- a/Canvas.js
+++ b/Canvas.js
@@ -750,8 +750,28 @@
                             return context.shadowOffsetY;
                         }
                     },
-                    shadowOffset = function() {
-                        //TODO, make one call if we need to set both!
+/**
+ * Gets/Sets shadowOffsetX and shadowOffsetY in one call.
+ * Passing no parameters returns an object containing the x and y offsets
+ * shadowOffset().x === shadowOffsetX() && shadowOffset().y === shadowOffsetY()
+ * 
+ * @param {integer} x shadowOffsetX
+ * @param {integer} y shadowOffsetY
+ */
+					shadowOffset = function(x, y) {
+						if (x !== undefined &&
+							y !== undefined){
+
+							context.shadowOffsetX = x;
+							context.shadowOffsetY = y;
+							return this;
+						}
+						else {
+							return {
+								x: context.shadowOffsetX,
+								y: context.shadowOffsetY
+							}
+						}
                     },
 /**
  * Draws a circle with the supplied starting x,y, radius and strokeStyle and no fill
@@ -878,6 +898,7 @@
                     setTransform : setTransform,
                     shadowBlur: shadowBlur,
                     shadowColor: shadowColor,
+					shadowOffset: shadowOffset,
                     shadowOffsetX: shadowOffsetX,
                     shadowOffsetY: shadowOffsetY,
                     stroke: stroke,

--- a/Canvas.js
+++ b/Canvas.js
@@ -752,6 +752,7 @@
                     },
 /**
  * Gets/Sets shadowOffsetX and shadowOffsetY in one call.
+ * Passing one parameter sets both shadowOffsetX and shadowOffsetY to the same value
  * Passing no parameters returns an object containing the x and y offsets
  * shadowOffset().x === shadowOffsetX() && shadowOffset().y === shadowOffsetY()
  *


### PR DESCRIPTION
Did TODO for single-method shadowOffset

Accepts (x, y) as separate params like other canvas methods.

Passing only 1 param sets both x and y to the same offset.

Passing no params acts as a getter, returning {x: NUM, y: NUM} so shadowOffset().x === shadowOffsetX() && shadowOffset().y === shadowOffsetY()
